### PR TITLE
chaged typography white-space to pre-wrap

### DIFF
--- a/src/Typography/styles.css
+++ b/src/Typography/styles.css
@@ -1,6 +1,6 @@
 .wrapper {
   word-wrap: break-word;
-  white-space: pre-line;
+  white-space: pre-wrap;
 }
 
 .caption1Normal {


### PR DESCRIPTION
allows sentences that have two or more styles to be separate polygolt elements with a space at the start or end. 
